### PR TITLE
Added skipping to asset_precompile task

### DIFF
--- a/lib/capistrano/stretcher/tasks/rails.rake
+++ b/lib/capistrano/stretcher/tasks/rails.rake
@@ -1,3 +1,5 @@
+# Original source about asset_precompile: https://github.com/capistrano-plugins/capistrano-faster-assets/blob/master/lib/capistrano/tasks/faster_assets.rake
+
 namespace :stretcher do
   set :exclude_dirs, fetch(:exclude_dirs) << "vendor/bundle" << "public/assets"
   set :assets_dependencies, %w(app/assets lib/assets vendor/assets Gemfile.lock config/routes.rb)

--- a/lib/capistrano/stretcher/tasks/rails.rake
+++ b/lib/capistrano/stretcher/tasks/rails.rake
@@ -1,4 +1,4 @@
-# Original source about asset_precompile: https://github.com/capistrano-plugins/capistrano-faster-assets/blob/master/lib/capistrano/tasks/faster_assets.rake
+# Original source about assets precompile: https://github.com/capistrano-plugins/capistrano-faster-assets/blob/master/lib/capistrano/tasks/faster_assets.rake
 
 namespace :stretcher do
   set :exclude_dirs, fetch(:exclude_dirs) << "vendor/bundle" << "public/assets"

--- a/lib/capistrano/stretcher/tasks/rails.rake
+++ b/lib/capistrano/stretcher/tasks/rails.rake
@@ -1,5 +1,9 @@
 namespace :stretcher do
   set :exclude_dirs, fetch(:exclude_dirs) << "vendor/bundle" << "public/assets"
+  set :assets_dependencies, %w(app/assets lib/assets vendor/assets Gemfile.lock config/routes.rb)
+
+  class PrecompileRequired < StandardError;
+  end
 
   def local_bundle_path
     @_local_bundle_path ||= fetch(:local_bundle_path, "vendor/bundle")
@@ -17,16 +21,33 @@ namespace :stretcher do
     on application_builder_roles do
       within local_build_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, :rake, 'assets:precompile'
-        end
-      end
-    end
-  end
+          begin
+            checkout_dirs = capture(:ls, '-xr', local_checkout_path)
+            latest_path = "#{local_checkout_path}/#{checkout_dirs.split[0]}"
+            previous_path = "#{local_checkout_path}/#{checkout_dirs.split[1]}"
 
-  task :cleanup_precompiled_assets do
-    on application_builder_roles do
-      within local_build_path do
-        execute :rm, '-rf', "public/assets"
+            raise PrecompileRequired unless previous_path
+
+            execute :ls, "#{previous_path}/public/assets" rescue raise PrecompileRequired
+
+            fetch(:assets_dependencies).each do |dep|
+              latest = "#{latest_path}/#{dep}"
+              previous = "#{previous_path}/#{dep}"
+              next if [latest, previous].map{|d| test "[ -e #{d} ]"}.uniq == [false]
+
+              execute :diff, '-Nqr', latest, previous rescue raise PrecompileRequired
+            end
+
+            info('Skipping asset precompile, no asset diff found')
+
+            execute :cp, '-r', "#{previous_path}/public/assets", "#{latest_path}/public/"
+
+          rescue PrecompileRequired
+            execute :rm, '-rf', 'public/assets'
+            execute :bundle, :exec, :rake, 'assets:precompile'
+            execute :cp, '-r', 'public/assets', "#{latest_path}/public/"
+          end
+        end
       end
     end
   end
@@ -34,4 +55,3 @@ end
 
 after 'stretcher:checkout_local', 'stretcher:bundle'
 before 'stretcher:create_tarball', 'stretcher:asset_precompile'
-after 'stretcher:cleanup_dirs', 'stretcher:cleanup_precompiled_assets'


### PR DESCRIPTION
Skip `assets:precompile` when that is unnecessary.
I convert [capistrano-faster-assets](https://github.com/capistrano-plugins/capistrano-faster-assets) for capistrano-stretcher-rails.

